### PR TITLE
Fix: Ensure new line between a recipe and workflow commands

### DIFF
--- a/random
+++ b/random
@@ -39,5 +39,6 @@ curl -sL "https://github.com/melpa/melpa/raw/master/recipes/$package" \
      > "$outfile"
 cat "$outfile"
 
+echo
 echo "::set-env name=PACKAGE::$package"
 echo "::set-env name=RECIPE_FILE::$outfile"


### PR DESCRIPTION
Fix a case like this: https://github.com/akirak/elinter-demo/runs/1076147420?check_suite_focus=true#step:7:33